### PR TITLE
Update use-hotkeys.md

### DIFF
--- a/packages/core/src/hooks/hotkeys/use-hotkeys.md
+++ b/packages/core/src/hooks/hotkeys/use-hotkeys.md
@@ -64,7 +64,7 @@ export default function() {
     return (
         <div tabIndex={0} onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
             Press "R" to refresh data, "F" to focus the input...
-            <InputGroup ref={inputRef} />
+            <InputGroup inputRef={inputRef} />
         </div>
     );
 }


### PR DESCRIPTION
The `inputRef` object should be assigned to the `inputRef` field of `InputGroup`
```
Type 'RefObject<HTMLInputElement>' is not assignable to type 'string | ((instance: InputGroup | null) => void) | RefObject<InputGroup> | null | undefined'.
  Type 'RefObject<HTMLInputElement>' is not assignable to type 'RefObject<InputGroup>'.
    Type 'HTMLInputElement' is missing the following properties from type 'InputGroup': state, leftElement, rightElement, refHandlers, and 24 more.ts(2322)
```

#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
